### PR TITLE
Mention prereqs in Readme for builds on vanilla Ubuntu

### DIFF
--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -27,6 +27,7 @@ Dependencies
  libssl      SSL Support       Secure communications
  libdb       Berkeley DB       Blockchain & wallet storage
  libboost    Boost             C++ Library
+ libevent    Libevent          Event notification library
  miniupnpc   UPnP Support      Optional firewall-jumping support
  libqrencode QRCode generation Optional QRCode generation
 
@@ -65,6 +66,7 @@ sudo apt-get install build-essential
 sudo apt-get install libssl-dev
 sudo apt-get install libdb++-dev
 sudo apt-get install libboost-all-dev
+sudo apt-get install libevent-dev
 sudo apt-get install libqrencode-dev
 
 If using Boost 1.37, append -mt to the boost libraries in the makefile.

--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -22,14 +22,14 @@ the graphical shadowcoin.
 Dependencies
 ------------
 
- Library     Purpose           Description
- -------     -------           -----------
- libssl      SSL Support       Secure communications
- libdb       Berkeley DB       Blockchain & wallet storage
- libboost    Boost             C++ Library
- libevent    Libevent          Event notification library
- miniupnpc   UPnP Support      Optional firewall-jumping support
- libqrencode QRCode generation Optional QRCode generation
+ Library      Purpose           Description
+ -------      -------           -----------
+ libssl       SSL Support       Secure communications
+ libdb        Berkeley DB       Blockchain & wallet storage
+ libboost     Boost             C++ Library
+ libevent     Libevent          Event notification library
+ miniupnpc    UPnP Support      Optional firewall-jumping support
+ libqrencode  QRCode generation Optional QRCode generation
 
 Note that libexecinfo should be installed, if you building under *BSD systems. 
 This library provides backtrace facility.
@@ -67,6 +67,7 @@ sudo apt-get install libssl-dev
 sudo apt-get install libdb++-dev
 sudo apt-get install libboost-all-dev
 sudo apt-get install libevent-dev
+sudo apt-get install libminiupnpc-dev
 sudo apt-get install libqrencode-dev
 
 If using Boost 1.37, append -mt to the boost libraries in the makefile.


### PR DESCRIPTION
mention `libevent-dev` and `libminiupnpc-dev` which seem to be required for `denariusd` build to succeed on vanilla Ubuntu installation.