### PR TITLE
Temp. fix for compiling masternodes branch on UNIX.

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -428,7 +428,9 @@ public:
 	
     void SetKey(const CKey& vchSecret)
     {
+		#ifdef _WIN32
         assert(vchSecret.IsValid());
+		#endif
         SetData(fTestNet ? PRIVKEY_ADDRESS_TEST : PRIVKEY_ADDRESS, vchSecret.begin(), vchSecret.size());
         if (vchSecret.IsCompressed())
             vchData.push_back(1);


### PR DESCRIPTION
Error in function setKey from base58.h on UNIX based OSses. Needs further investigation if wants to be fixed cleanly.