### PR TITLE
show a splash screen while wallet closes

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -201,9 +201,11 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    // show a persistent splash screen unless it is disabled from flags
     QSplashScreen splash(QPixmap(":/images/splash"), 0);
     if (GetBoolArg("-splash", true) && !GetBoolArg("-min"))
     {
+        splash.setEnabled(false);
         splash.show();
         splashref = &splash;
     }
@@ -261,6 +263,14 @@ int main(int argc, char *argv[])
                 window.setMessageModel(0);
                 guiref = 0;
             }
+
+            // Show a persistent splash screen while shutting down
+            QSplashScreen splash(QPixmap(":/images/splash"), 0);
+            splash.setEnabled(false);
+            splash.show();
+            splashref = &splash;
+            uiInterface.InitMessage(_("Denarius is shutting down, please do not turn off your computer..."));
+
             // Shutdown the core and its threads, but don't exit Bitcoin-Qt here
             Shutdown(NULL);
         }


### PR DESCRIPTION
resolves #46 
additionally makes splash screen persistent on both startup and shutdown - will not close when clicked