### PR TITLE
performance and consensus improvements

### DIFF
--- a/src/fortunastake.cpp
+++ b/src/fortunastake.cpp
@@ -531,8 +531,6 @@ bool GetFortunastakeRanks(CBlockIndex* pindex)
 {
     if (!pindex || pindex == NULL || pindex->pprev == NULL || IsInitialBlockDownload() || vecFortunastakes.size() == 0) return true;
 
-    //vecFortunastakeScores.clear();
-
     if (vecFortunastakeScoresListHash.size() > 0 && vecFortunastakeScoresListHash == pindex->GetBlockHash()) {
         // if ScoresList was calculated for the current pindex hash, then just use that list
         // TODO: make a vector of these somehow
@@ -542,6 +540,7 @@ bool GetFortunastakeRanks(CBlockIndex* pindex)
         //    vecFortunastakeScores.push_back(make_pair(i, &mn));
         //}
     } else {
+        vecFortunastakeScores.clear();
         vecFortunastakeScoresList.clear();
 
         BOOST_FOREACH(CFortunaStake& mn, vecFortunastakes) {

--- a/src/fortunastake.cpp
+++ b/src/fortunastake.cpp
@@ -432,10 +432,10 @@ struct CompareLastPay
     bool operator()(const pair<int, CFortunaStake*>& t1,
                     const pair<int, CFortunaStake*>& t2) const
     {
-        if (t1.second->IsActive(pindex) == t2.second->IsActive(pindex)) {
+        if (t1.second->IsActive() == t2.second->IsActive()) {
             return (t1.second->payValue == t2.second->payValue ? t1.second->CalculateScore(1, pindex->nHeight) > t2.second->CalculateScore(1, pindex->nHeight) : t1.second->payValue > t2.second->payValue);
         } else {
-            if (t1.second->IsActive(pindex) < t2.second->IsActive(pindex)) return true; //always put actives before non-actives
+            return (t1.second->IsActive() < t2.second->IsActive()); //always put actives before non-actives
         }
         return false;
     }

--- a/src/fortunastake.cpp
+++ b/src/fortunastake.cpp
@@ -529,18 +529,18 @@ int GetCurrentFortunaStake(int mod, int64_t nBlockHeight, int minProtocol)
 
 bool GetFortunastakeRanks(CBlockIndex* pindex)
 {
-    if (!pindex || IsInitialBlockDownload() || vecFortunastakes.size() == 0) return true;
+    if (!pindex || pindex == NULL || pindex->pprev == NULL || IsInitialBlockDownload() || vecFortunastakes.size() == 0) return true;
 
-    vecFortunastakeScores.clear();
-    int i = 0;
-    if (vecFortunastakeScoresListHash == pindex->GetBlockHash()) {
+    //vecFortunastakeScores.clear();
+
+    if (vecFortunastakeScoresListHash.size() > 0 && vecFortunastakeScoresListHash == pindex->GetBlockHash()) {
         // if ScoresList was calculated for the current pindex hash, then just use that list
         // TODO: make a vector of these somehow
-        BOOST_FOREACH(CFortunaStake& mn, vecFortunastakeScoresList)
-        {
-            i++;
-            vecFortunastakeScores.push_back(make_pair(i, &mn));
-        }
+        //BOOST_FOREACH(CFortunaStake& mn, vecFortunastakeScoresList)
+        //{
+        //    i++;
+        //    vecFortunastakeScores.push_back(make_pair(i, &mn));
+        //}
     } else {
         vecFortunastakeScoresList.clear();
 
@@ -569,6 +569,7 @@ bool GetFortunastakeRanks(CBlockIndex* pindex)
 
     sort(vecFortunastakeScores.rbegin(), vecFortunastakeScores.rend(), CompareLastPay(pindex)); // sort requires current pindex for modulus as pindexBest is different between clients
 
+    int i = 0;
     // set ranks
     BOOST_FOREACH(PAIRTYPE(int, CFortunaStake*)& s, vecFortunastakeScores)
     {
@@ -702,10 +703,10 @@ int CFortunaStake::SetPayRate(int nHeight)
          // printf(" (payInfo:%d@%f)...", payCount, payRate);
          int64_t amount = 0;
          int matches = 0;
-         BOOST_FOREACH(PAIRTYPE(int, int64_t) &item, payData)
+         BOOST_FOREACH(CFortunaPayData &item, payData)
          {
-             if (item.first > nHeight - scanBack) { // find payments in last scanrange
-                amount += item.second;
+             if (item.height > nHeight - scanBack && mapBlockIndex.count(item.hash)) { // find payments in last scanrange
+                amount += item.amount;
                 matches++;
              }
          }
@@ -734,10 +735,10 @@ int CFortunaStake::GetPaymentAmount(const CBlockIndex *pindex, int nMaxBlocksToS
         //printf("(payInfo:%d@%f)...", payCount, payRate);
         int64_t amount = 0;
         int matches = 0;
-        BOOST_FOREACH(PAIRTYPE(int, int64_t) &item, payData)
+        BOOST_FOREACH(CFortunaPayData &item, payData)
         {
-            if (item.first > pindex->nHeight - nMaxBlocksToScanBack) { // find payments in last scanrange
-               amount += item.second;
+            if (item.height > pindex->nHeight - nMaxBlocksToScanBack && mapBlockIndex.count(item.hash)) { // find payments in last scanrange
+               amount += item.amount;
                matches++;
             }
         }
@@ -792,20 +793,31 @@ int CFortunaStake::UpdateLastPaidAmounts(const CBlockIndex *pindex, int nMaxBloc
 
     //if (now > pindex->GetBlockTime()) return 0; // don't update paid amounts for nodes before the block they broadcasted on
     if (payData.size()) {
-        // when operating on cache, prune old entries to keep this at exactly the last 600 blocks.
+        // when operating on cache, prune old entries to keep this at exactly the last 600 blocks. (note: don't do this)
         // if a node doesn't get any reorgs, it won't clear old payments here and the average amount will increase
         // then they will approve high rates, leading to other nodes who DID reorg seeing the average lower and rejecting it.
-
-        std::vector<pair<int, int64_t> >::iterator it = payData.begin();
-        while(it != payData.end()){
-            if ((*it).first > pindex->nHeight - scanBack) { // find payments in last scanrange
-               rewardValue += (*it).second;
-               rewardCount++;
-               ++it;
-            } else {
-                // remove it from payData
-                if (fDebug) { printf("Removing old payData for FS %s at height %d\n",addr.ToString().c_str(),(*it).first); }
-                it = payData.erase(it);
+        /*
+                std::vector<pair<int, int64_t> >::iterator it = payData.begin();
+                while(it != payData.end()){
+                    if ((*it).first > pindex->nHeight - scanBack) { // find payments in last scanrange
+                       rewardValue += (*it).second;
+                       rewardCount++;
+                       ++it;
+                    } else {
+                        // remove it from payData
+                        if (fDebug) { printf("Removing old payData for FS %s at height %d\n",addr.ToString().c_str(),(*it).first); }
+                        it = payData.erase(it);
+                    }
+                }
+        */
+        // all of that doesn't matter if we pay attention to the hash of the payment!
+        BOOST_FOREACH(CFortunaPayData &item, payData)
+        {
+            if (mapBlockIndex.count(item.hash)) {
+                if (item.height > pindex->nHeight - nMaxBlocksToScanBack) { // find payments in last scanrange
+                rewardValue += item.amount;
+                rewardCount++;
+                }
             }
         }
 
@@ -841,21 +853,28 @@ int CFortunaStake::UpdateLastPaidAmounts(const CBlockIndex *pindex, int nMaxBloc
             {
                 BOOST_FOREACH(CTxOut txout, block.vtx[block.IsProofOfWork() ? 0 : 1].vout)
                 {
+
                     if(mnpayee == txout.scriptPubKey) {
                         int height = BlockReading->nHeight;
-                        if (rewardCount == 0) {
-                            nBlockLastPaid = height;
-                            nTimeLastPaid = BlockReading->nTime;
-                        }
-                        // values
-                        val = txout.nValue;
+                        int64_t amount = txout.nValue;
+                        uint256 hash = BlockReading->GetBlockHash();
+                        CFortunaPayData data;
 
-                        // add this profit & the reward itself
-                        rewardValue += val;
+                        data.height = height;
+                        data.amount = amount;
+                        data.hash = hash;
+
+                        // first match is the last! ;)
+                        if (nBlockLastPaid == 0) {
+                            nBlockLastPaid = height;
+                        }
+
+                        // add this profit & the reward itself so we can update the node
+                        rewardValue += amount;
                         rewardCount++;
 
                         // make a note in the node for later lookup
-                        payData.push_back(make_pair(height, val));
+                        payData.push_back(data);
                     }
                 }
             }
@@ -919,7 +938,6 @@ void CFortunaStake::UpdateLastPaidBlock(const CBlockIndex *pindex, int nMaxBlock
                 BOOST_FOREACH(CTxOut txout, block.vtx[0].vout)
                     if(mnpayee == txout.scriptPubKey) {
                         nBlockLastPaid = BlockReading->nHeight;
-                        nTimeLastPaid = BlockReading->nTime;
                         int lastPay = pindexBest->nHeight - nBlockLastPaid;
                         int value = txout.nValue;
                         // TODO HERE: Check the nValue for the fortunastake payment amount
@@ -931,8 +949,7 @@ void CFortunaStake::UpdateLastPaidBlock(const CBlockIndex *pindex, int nMaxBlock
                 // TODO HERE: Scan the block for fortunastake payment amount
                 BOOST_FOREACH(CTxOut txout, block.vtx[1].vout)
                     if(mnpayee == txout.scriptPubKey) {
-                        nBlockLastPaid = BlockReading->nHeight;
-                        nTimeLastPaid = BlockReading->nTime;
+                        nBlockLastPaid = BlockReading->nHeight;\
                         int lastPay = pindexBest->nHeight - nBlockLastPaid;
                         int value = txout.nValue;
                         // TODO HERE: Check the nValue for the fortunastake payment amount

--- a/src/fortunastake.h
+++ b/src/fortunastake.h
@@ -81,6 +81,29 @@ public:
 
 };
 
+// For storing payData
+class CFortunaPayments
+{
+public:
+    std::vector<CFortunaStake> vStakes; // this array should be sorted
+    std::vector<CFortunaPayData> vPayments; // this array just contains our scanned data
+    
+    CFortunaPayments() {
+        // fill vStakes array with pointers to MN's from vecFortunastakes
+    }
+
+    bool add(CFortunaStake* mn)
+    {
+        // add address of pointer into the payments array
+    }
+
+    bool remove(CFortunaStake* mn)
+    {
+        // remove address of pointer from the payments array
+        
+    }
+};
+
 //
 // The Fortunastake Class. For managing the fortuna process. It contains the input of the 5000 D, signature to prove
 // it's the one who own that ip address and code for calculating the payment election.
@@ -160,10 +183,17 @@ public:
         }
     }
 
-    int IsActive(CBlockIndex* pindex) {
-        return ((lastDseep > (GetAdjustedTime() - FORTUNASTAKE_MIN_DSEEP_SECONDS)) &&
-                (lastTimeSeen - now > (max(FORTUNASTAKE_FAIR_PAYMENT_MINIMUM, (int)mnCount) * 30))
-                ); // dsee broadcast is more than a round old & active from dseeps
+    bool IsActive() {
+        if (lastTimeSeen - now > (max(FORTUNASTAKE_FAIR_PAYMENT_MINIMUM, (int)mnCount) * 30))
+        { // dsee broadcast is more than a round old
+            if (lastDseep > (GetAdjustedTime() - FORTUNASTAKE_EXPIRATION_SECONDS)) {
+                return true;
+            } // last dseep is within non-expired time & broadcast is a round old, this node is considered active
+            else {
+                return false; // last dseep is received, but broadcast is not new enough. status "broadcasted"
+            }
+        }
+        return false;
     }
 
     inline uint64_t SliceHash(uint256& hash, int slice)

--- a/src/fortunastake.h
+++ b/src/fortunastake.h
@@ -65,6 +65,22 @@ int CountFortunastakesAboveProtocol(int protocolVersion);
 void ProcessMessageFortunastake(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 bool CheckFortunastakeVin(CTxIn& vin, std::string& errorMessage, CBlockIndex *pindex);
 
+// For storing payData
+class CFortunaPayData
+{
+public:
+    int height;
+    uint256 hash;
+    int64_t amount;
+
+    CFortunaPayData() {
+        height = 0;
+        hash = 0;
+        amount = 0;
+    }
+
+};
+
 //
 // The Fortunastake Class. For managing the fortuna process. It contains the input of the 5000 D, signature to prove
 // it's the one who own that ip address and code for calculating the payment election.
@@ -79,7 +95,7 @@ public:
     CPubKey pubkey;
     CPubKey pubkey2;
     std::vector<unsigned char> sig;
-    std::vector<pair<int, int64_t> > payData;
+    std::vector<CFortunaPayData> payData;
     pair<int, int64_t> payInfo;
     int64_t payRate;
     int payCount;
@@ -96,7 +112,6 @@ public:
     int64_t lastTimeChecked;
     int nBlockLastPaid;
     int64_t nTimeLastChecked;
-    int64_t nTimeLastPaid;
     int64_t nTimeRegistered;
     int nRank;
 
@@ -123,7 +138,6 @@ public:
         lastTimeChecked = 0;
         nBlockLastPaid = 0;
         nTimeLastChecked = 0;
-        nTimeLastPaid = 0;
         nTimeRegistered = newNow;
         nRank = 0;
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -465,8 +465,8 @@ bool AppInit2()
 
     nNodeLifespan = GetArg("-addrlifespan", 7);
     fUseFastIndex = GetBoolArg("-fastindex", true);
-    nMinStakeInterval = GetArg("-minstakeinterval", 30);
-    nMinerSleep = GetArg("-minersleep", 30000); //500
+    nMinStakeInterval = GetArg("-minstakeinterval", 60); // 2 blocks, don't make pos chains!
+    nMinerSleep = GetArg("-minersleep", 10000); //default 10seconds, higher=more cpu usage
 
     // Largest block you're willing to create.
     // Limit to betweeen 1K and MAX_BLOCK_SIZE-1K for sanity:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2556,21 +2556,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
                                     if (vtx[1].vout[i].scriptPubKey == pubScript)
                                     {
                                         int64_t value = vtx[1].vout[i].nValue;
-                                        int lastPaid = mn.nBlockLastPaid;
-                                        int vinAge = mn.GetFortunastakeInputAge(pindex);
-                                        int rank = (GetFortunastakeRank(mn, pindex));
-                                        int maxrank = mnCount-(mnCount/10);
-                                        if (fDebug) printf("CheckBlock-POS() : Fortunastake PoS payee found at block %d: %s who got paid %s D rate:%d age: %d, rank %d\n", pindex->nHeight, address2.ToString().c_str(), FormatMoney(value).c_str(), mn.payRate, vinAge, rank);
-
-                                        if(vinAge < (nBestHeight > BLOCK_START_FORTUNASTAKE_DELAYPAY ? FORTUNASTAKE_MIN_CONFIRMATIONS_NOPAY : FORTUNASTAKE_MIN_CONFIRMATIONS)) // if MN is too new
-                                        {
-                                            if (pindexBest->nHeight >= MN_ENFORCEMENT_ACTIVE_HEIGHT) {
-                                                return error("CheckBlock-POS() : Fortunastake has only %d confirmations (requires %d) - rejecting block.", vinAge, FORTUNASTAKE_MIN_CONFIRMATIONS_NOPAY);
-                                            } else {
-                                                if (fDebug) printf("WARNING: Fortunastake has only %d confirmations (requires %d) and will not be accepted after block %d\n", vinAge, FORTUNASTAKE_MIN_CONFIRMATIONS_NOPAY, MN_ENFORCEMENT_ACTIVE_HEIGHT);
-                                            }
-                                            break;
-                                        }
+                                        if (fDebug) printf("CheckBlock-POS() : Fortunastake PoS payee found at block %d: %s who got paid %s D rate:%"PRId64" rank:%d lastpaid:%d\n", pindex->nHeight, address2.ToString().c_str(), FormatMoney(value).c_str(), mn.payRate, mn.nRank, mn.nBlockLastPaid);
 
                                         if (!fIsInitialDownload) {
                                             if (!CheckFSPayment(pindex, vtx[1].vout[i].nValue, mn)) // if MN is being paid and it's bottom 50% ranked, don't let it be paid.
@@ -2681,29 +2667,13 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
 
                                 if (payee == pubScript)
                                 {
-                                    int lastPaid = mn.nBlockLastPaid;
-                                    int vinAge = mn.GetFortunastakeInputAge(pindex);
-                                    int rank = (GetFortunastakeRank(mn, pindex));
-                                    int maxrank = mnCount - (mnCount/10);
-
-                                    if (fDebug) printf("CheckBlock-POW() : Fortunastake PoW payee found at block %d: %s who got paid %s D rate:%d age: %d, rank %d\n", pindex->nHeight+1, address2.ToString().c_str(), FormatMoney(vtx[0].vout[i].nValue).c_str(), FormatMoney(mn.payRate).c_str(), vinAge, rank);
-
-                                    if(vinAge < (nBestHeight > BLOCK_START_FORTUNASTAKE_DELAYPAY ? FORTUNASTAKE_MIN_CONFIRMATIONS_NOPAY : FORTUNASTAKE_MIN_CONFIRMATIONS)) // if MN is too new
-                                    {
-                                        if (pindexBest->nHeight >= MN_ENFORCEMENT_ACTIVE_HEIGHT) {
-                                            return error("CheckBlock-POW() : Fortunastake has only %d confirmations (requires %d) - rejecting block.", vinAge, FORTUNASTAKE_MIN_CONFIRMATIONS_NOPAY);
-                                        } else {
-                                            if (fDebug) printf("WARNING: Fortunastake has only %d confirmations (requires %d) and will not be accepted after block %d\n", vinAge ,FORTUNASTAKE_MIN_CONFIRMATIONS_NOPAY, MN_ENFORCEMENT_ACTIVE_HEIGHT);
-                                        }
-                                        break;
-                                    }
-
+                                    if (fDebug) printf("CheckBlock-POW() : Fortunastake PoW payee found at block %d: %s who got paid %s D rate:%"PRId64" rank:%d lastpaid:%d\n", pindex->nHeight, address2.ToString().c_str(), FormatMoney(vtx[0].vout[i].nValue).c_str(), FormatMoney(mn.payRate).c_str(), mn.nRank, mn.nBlockLastPaid);
                                     if (!fIsInitialDownload) {
                                         if (!CheckFSPayment(pindex, vtx[0].vout[i].nValue, mn)) // if MN is being paid and it's bottom 50% ranked, don't let it be paid.
                                         {
                                             if (pindexBest->nHeight >= MN_ENFORCEMENT_ACTIVE_HEIGHT)
                                             {
-                                                return error("CheckBlock-POW() : Fortunastake overpayment detected, rejecting block. rank:%d payRate:%d",rank,FormatMoney(mn.payRate).c_str());
+                                                return error("CheckBlock-POW() : Fortunastake overpayment detected, rejecting block. rank:%d value:%s avg:%s payRate:%s",mn.nRank,FormatMoney(mn.payValue).c_str(),FormatMoney(nAverageFSIncome).c_str(),FormatMoney(mn.payRate).c_str());
                                             } else
                                             {
                                                 if (fDebug) printf("WARNING: This fortunastake payment is too aggressive and will not be accepted after block %d\n", MN_ENFORCEMENT_ACTIVE_HEIGHT);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3453,6 +3453,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
 {
     AssertLockHeld(cs_main);
 
+    int64_t nStartTime = GetTimeMillis();
     // Check for duplicate
     uint256 hash = pblock->GetHash();
     if (mapBlockIndex.count(hash))
@@ -3574,7 +3575,11 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
         mapOrphanBlocksByPrev.erase(hashPrev);
     }
 
-    if (fDebug) printf("ProcessBlock: ACCEPTED\n");
+    if (fDebug && GetBoolArg("-showtimers", false)) {
+        printf("ProcessBlock: ACCEPTED (%"PRId64"ms)\n", GetTimeMillis() - nStartTime);
+    } else {
+        if (fDebug) printf("ProcessBlock: ACCEPTED\n");
+    }
 
     //After block 1.5m, The Minimum FortunaStake Protocol Version is 31005
     if(nBestHeight >= 1500000) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2575,7 +2575,11 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
                                         }
                                         // add mn payment data
                                         mn.nBlockLastPaid = pindex->nHeight;
-                                        mn.payData.push_back(make_pair(pindex->nHeight, value));
+                                        CFortunaPayData data;
+                                        data.height = pindex->nHeight;
+                                        data.amount = value;
+                                        data.hash = pindex->GetBlockHash();
+                                        mn.payData.push_back(data);
                                         mn.SetPayRate(pindex->nHeight);
                                         foundPayee = true;
                                         paymentOK = true;
@@ -2686,7 +2690,11 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
                                     }
 
                                     mn.nBlockLastPaid = pindex->nHeight;
-                                    mn.payData.push_back(make_pair(pindex->nHeight, vtx[0].vout[i].nValue));
+                                    CFortunaPayData data;
+                                    data.height = pindex->nHeight;
+                                    data.amount = vtx[0].vout[i].nValue;
+                                    data.hash = pindex->GetBlockHash();
+                                    mn.payData.push_back(data);
                                     mn.SetPayRate(pindex->nHeight);
                                     foundPayee = true;
                                     paymentOK = true;
@@ -2935,12 +2943,6 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
         mempool.remove(tx);
         mempool.removeConflicts(tx);
     }
-
-    BOOST_FOREACH(CFortunaStake& mn, vecFortunastakes) // now clear the ranks because we need to reorganize the payments in case extras got in
-    {
-        mn.payData.clear();
-    }
-    if (!IsInitialBlockDownload()) GetFortunastakeRanks(pindex); // recalculate ranks for the this block hash if required
 
     FortunaReorgBlock = false;
     printf("REORGANIZE: done\n");

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -722,7 +722,7 @@ void StakeMiner(CWallet *pwallet)
             continue;
         };
 
-        if (vecFortunastakes.size() == 0 || (mnCount > 0 && vecFortunastakes.size() < mnCount))
+        if (vecFortunastakes.size() == 0)
         {
             if (fDebug && GetBoolArg("-printcoinstake")) printf("StakeMiner() waiting for FS list.");
             vnThreadsRunning[THREAD_STAKE_MINER]--;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -187,7 +187,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
 				bFortunaStakePayment = true;
 			}
 		}
-        if(fDebug) { printf("CreateNewBlock(): Fortunastake Payments : %i\n", bFortunaStakePayment); }
+        if(fDebug && fDebugFS) { printf("CreateNewBlock(): Fortunastake Payments : %i\n", bFortunaStakePayment); }
 	}
 
     // Fee-per-kilobyte amount considered the same as "free"
@@ -226,7 +226,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
                 }
                 }
                 if (found) {
-                    printf("CreateNewBlock: Found a fortunastake to pay: %s\n",payee.ToString(true).c_str());
+                    if (fDebug && fDebugFS) printf("CreateNewBlock: Found a fortunastake to pay: %s\n",payee.ToString(true).c_str());
                 } else {
                     printf("CreateNewBlock: Failed to detect fortunastake to pay\n");
                     // pay the burn address if it can't detect
@@ -242,7 +242,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
 
             if(hasPayment){
                 payments = txNew.vout.size() + 1;
-                printf("CreateNewBlock(): Payment Size: %i\n", payments);
+                if (fDebug && fDebugNet) printf("CreateNewBlock(): Payment Size: %i\n", payments);
                 pblock->vtx[0].vout.resize(payments);
 
                 pblock->vtx[0].vout[payments-1].scriptPubKey = payee;
@@ -252,7 +252,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int64_t* pFees)
                 ExtractDestination(payee, address1);
                 CBitcoinAddress address2(address1);
 
-                printf("CreateNewBlock(): Fortunastake payment to %s\n", address2.ToString().c_str());
+                if (fDebug && fDebugFS) printf("CreateNewBlock(): Fortunastake payment to %s\n", address2.ToString().c_str());
             }
         }
 

--- a/src/qt/fortunastakemanager.cpp
+++ b/src/qt/fortunastakemanager.cpp
@@ -296,7 +296,7 @@ void FortunastakeManager::updateNodeList()
         // populate list
         // Address, Rank, Active, Active Seconds, Last Seen, Pub Key
         QTableWidgetItem *activeItem = new QTableWidgetItem();
-        activeItem->setData(Qt::DisplayRole, QString::fromStdString(mn.IsActive(pindexBest) ? "Y" : "N"));
+        activeItem->setData(Qt::DisplayRole, QString::fromStdString(mn.IsActive() ? "Y" : "N"));
         QTableWidgetItem *addressItem = new QTableWidgetItem();
         addressItem->setData(Qt::EditRole, QString::fromStdString(mn.addr.ToString()));
         SortedWidgetItem *rankItem = new SortedWidgetItem();
@@ -342,7 +342,7 @@ void FortunastakeManager::updateNodeList()
                 found = true;
                 nalias = QString::fromStdString(mne.getAlias());
                 naddr = QString::fromStdString(mne.getIp());
-                if (mn.IsActive(pindexBest)) {
+                if (mn.IsActive()) {
                     nstatus = QString::fromStdString("Active for payment");
                 } else if (mn.status == "OK") {
                     if (mn.lastDseep > 0) {

--- a/src/rpcfortuna.cpp
+++ b/src/rpcfortuna.cpp
@@ -230,7 +230,7 @@ Value fortunastake(const Array& params, bool fHelp)
             mn.Check();
 
             if(strCommand == "active"){
-                obj.push_back(Pair(mn.addr.ToString().c_str(),       (int)mn.IsActive(pindexBest)));
+                obj.push_back(Pair(mn.addr.ToString().c_str(),       (int)mn.IsActive()));
             } else if (strCommand == "txid") {
                 obj.push_back(Pair(mn.addr.ToString().c_str(),       mn.vin.prevout.hash.ToString().c_str()));
             } else if (strCommand == "pubkey") {
@@ -262,7 +262,7 @@ Value fortunastake(const Array& params, bool fHelp)
             }
 			else if (strCommand == "full") {
                 Object list;
-                list.push_back(Pair("active",        (int)mn.IsActive(pindexBest)));
+                list.push_back(Pair("active",        (int)mn.IsActive()));
                 list.push_back(Pair("txid",           mn.vin.prevout.hash.ToString().c_str()));
                 list.push_back(Pair("n",       (int64_t)mn.vin.prevout.n));
 
@@ -584,8 +584,8 @@ Value fortunastake(const Array& params, bool fHelp)
                         address = address2.ToString();
                         localObj.push_back(Pair("payment_address", address));
                         //localObj.push_back(Pair("rank", GetFortunastakeRank(mn, pindexBest)));
-                        localObj.push_back(Pair("network_status", mn.IsActive(pindexBest) ? "active" : "registered"));
-                        if (mn.IsActive(pindexBest)) {
+                        localObj.push_back(Pair("network_status", mn.IsActive() ? "active" : "registered"));
+                        if (mn.IsActive()) {
                           localObj.push_back(Pair("activetime",(mn.lastTimeSeen - mn.now)));
 
                         }

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -533,7 +533,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     } else {
         if(pindexPrev->nHeight+1 >= BLOCK_START_FORTUNASTAKE_PAYMENTS) bFortunastakePayments = true;
     }
-	if(fDebug) { printf("GetBlockTemplate(): Fortunastake Payments : %i\n", bFortunastakePayments); }
+    if(fDebug && fDebugFS) { printf("GetBlockTemplate(): Fortunastake Payments : %i\n", bFortunastakePayments); }
 
     if(!fortunastakePayments.GetBlockPayee(pindexPrev->nHeight+1, payee)){
         //no fortunastake detected
@@ -563,7 +563,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
                     payee = GetScriptForDestination(burnAddr.Get());
                 }
     }
-    printf("getblock : payee = %i, bFortunastake = %i\n",payee != CScript(),bFortunastakePayments);
+    if (fDebug && fDebugNet) printf("getblock : payee = %i, bFortunastake = %i\n",payee != CScript(),bFortunastakePayments);
     if(payee != CScript()){
 		CTxDestination address1;
 		ExtractDestination(payee, address1);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3403,7 +3403,11 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 
     // Select coins with suitable depth
     if (!SelectCoinsForStaking(nBalance - nReserveBalance, txNew.nTime, setCoins, nValueIn))
+    {
+        if (fDebug && GetBoolArg("-printcoinstakedebug"))
+            printf("CreateCoinStake() : valid staking coins not found\n");
         return false;
+    }
 
     if (setCoins.empty())
         return false;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3428,13 +3428,15 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 continue;
         }
 
-        static int nMaxStakeSearchInterval = 60;
+        static int nMaxStakeSearchInterval = 30;
         if (block.GetBlockTime() + nStakeMinAge > txNew.nTime - nMaxStakeSearchInterval)
             continue; // only count coins meeting min age requirement
 
         bool fKernelFound = false;
         for (unsigned int n=0; n<min(nSearchInterval,(int64_t)nMaxStakeSearchInterval) && !fKernelFound && !fShutdown && pindexPrev == pindexBest; n++)
         {
+            if (fDebug && GetBoolArg("-printcoinstakedebug"))
+                printf("CreateCoinStake() : searching backward in time from %ld for %d seconds to %d\n",txNew.nTime,nSearchInterval,nMaxStakeSearchInterval);
             // Search backward in time from the given txNew timestamp
             // Search nSearchInterval seconds back up to nMaxStakeSearchInterval
             uint256 hashProofOfStake = 0, targetProofOfStake = 0;
@@ -3511,6 +3513,8 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         if (fKernelFound || fShutdown)
             break; // if kernel is found stop searching
     }
+
+
 
     if (nCredit == 0 || nCredit > nBalance - nReserveBalance)
         return false;


### PR DESCRIPTION
moved historical paydata to reference only blocks in main chain. pruning no longer required, and paydata loops will only need to be searched once per node; after this we just filter the paydata by height & mapBlockIndex.

some minor performance improvements in the FPS checker (checking input vins too vigorously)

also improved the stability/reliability of stake generation, the wallet should now stake effectively as soon as your coin is mature.